### PR TITLE
Fix one hot computation 

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -197,10 +197,7 @@ class RNN(nn.Module):
         return x, hxs
 
 def one_hot(dim, inputs, device='cpu'):
-    B = inputs.shape[0]
-    one_hot = torch.zeros(B, dim, device=device)
-    one_hot[:, inputs.long()] = 1
-
+    one_hot = torch.nn.functional.one_hot(inputs.long(), dim).squeeze(1).float()
     return one_hot
 
 def make_fc_layers_with_hidden_sizes(sizes, input_size):


### PR DESCRIPTION
Replaces the one_hot function with torch.nn.functional.one_hot.

The current implementation sets elements for each index and for each row to 1.